### PR TITLE
feat(output): add support for emitting credential provider JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | Preselect the AWS IAM Identity Provider ARN (optional) | `OKTA_AWSCLI_IAM_IDP` | `--aws-iam-idp [value]` | Preselects the IdP list to this preferred IAM Identity Provider. If there are other IdPs available they will not be listed. |
 | Preselects the AWS IAM Role ARN to assume (optional) | `OKTA_AWSCLI_IAM_ROLE` | `--aws-iam-role [value]` | Preselects the role list to this preferred IAM role for the given IAM Identity Provider. If there are other Roles available they will not be listed. |
 | AWS Session Duration (optional) | `OKTA_AWSCLI_SESSION_DURATION` | `--session-duration [value]` | The lifetime, in seconds, of the AWS credentials. Must be between 60 and 43200. |
-| Output format (optional) | `OKTA_AWSCLI_FORMAT` | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file |
+| Output format (optional) | `OKTA_AWSCLI_FORMAT` | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file, `credential-provider` for output in the [credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html) format |
 | Profile (optional) | `OKTA_AWSCLI_PROFILE` | `--profile [value]` | Default is `default`  |
 | Display QR Code (optional) | `OKTA_AWSCLI_QR_CODE=true` | `--qr-code` | `true` if flag is present  |
 | Automatically open the activation URL with the system web browser (optional) | `OKTA_AWSCLI_OPEN_BROWSER=true` | `--open-browser` | `true` if flag is present  |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvar
 that can be used for the AWS CLI configuration. Output can also be expressed as
 [credential file
 values](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
-for AWS CLI configuration.
+for AWS CLI configuration, or in the [credential provider
+format](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html).
 
 Configuration can be done with command line flags, environment variables, an
 `.env` file, or a combination of the three. The first value found in that
@@ -222,7 +223,7 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | Preselect the AWS IAM Identity Provider ARN (optional) | `OKTA_AWSCLI_IAM_IDP` | `--aws-iam-idp [value]` | Preselects the IdP list to this preferred IAM Identity Provider. If there are other IdPs available they will not be listed. |
 | Preselects the AWS IAM Role ARN to assume (optional) | `OKTA_AWSCLI_IAM_ROLE` | `--aws-iam-role [value]` | Preselects the role list to this preferred IAM role for the given IAM Identity Provider. If there are other Roles available they will not be listed. |
 | AWS Session Duration (optional) | `OKTA_AWSCLI_SESSION_DURATION` | `--session-duration [value]` | The lifetime, in seconds, of the AWS credentials. Must be between 60 and 43200. |
-| Output format (optional) | `OKTA_AWSCLI_FORMAT` | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file, `credential-provider` for output in the [credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html) format |
+| Output format (optional) | `OKTA_AWSCLI_FORMAT` | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file, `credential-provider` for output in the credential provider format |
 | Profile (optional) | `OKTA_AWSCLI_PROFILE` | `--profile [value]` | Default is `default`  |
 | Display QR Code (optional) | `OKTA_AWSCLI_QR_CODE=true` | `--qr-code` | `true` if flag is present  |
 | Automatically open the activation URL with the system web browser (optional) | `OKTA_AWSCLI_OPEN_BROWSER=true` | `--open-browser` | `true` if flag is present  |
@@ -481,6 +482,40 @@ Otherwise an `Unable to parse config file` error like the following may occur.
 aws --profile example s3 ls
 
 Unable to parse config file: /home/user/.aws/credentials
+```
+
+### AWS credential provider orientated usage
+
+**NOTE**: this example assumes other Okta AWS CLI configuration values have already been
+set by ENV variables or a `.env` file.
+
+Edit the [AWS configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+In either the `[default]` section or a profile section, add the following
+[configuration setting](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html)
+(the "test" profile is used as an example):
+
+```ini
+[profile test]
+
+credential_process = okta-aws-cli --open-browser --format credential-provider --cache-access-token
+```
+
+Once this is saved, you can run AWS CLI commands or apps that utilize
+AWS SDK APIs and `okta-aws-cli` will automatically be run as part of
+the credential provider chain.
+
+```shell
+$ aws --profile test s3 ls
+
+Open the following URL to begin Okta device authorization for the AWS CLI.
+
+https://test-org.okta.com/activate?user_code=ZNQZQXQQ
+
+? Choose an IdP: arn:aws:iam::123456789012:saml-provider/My_IdP
+? Choose a Role: arn:aws:iam::456789012345:role/My_Role
+
+2018-04-04 11:56:00 test-bucket
+2021-06-10 12:47:11 mah-bucket
 ```
 
 ### Help

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ credential_process = okta-aws-cli --open-browser --format credential-provider --
 ```
 
 Once this is saved, you can run AWS CLI commands or apps that utilize
-AWS SDK APIs and `okta-aws-cli` will automatically be run as part of
+AWS SDK APIs, and `okta-aws-cli` will automatically be run as part of
 the credential provider chain.
 
 ```shell

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -105,7 +105,7 @@ func init() {
 			name:   config.FormatFlag,
 			short:  "f",
 			value:  "",
-			usage:  "Output format. [env-var|aws-credentials|credentials-provider]",
+			usage:  "Output format. [env-var|aws-credentials|credential-provider]",
 			envVar: config.FormatEnvVar,
 		},
 		{

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -105,7 +105,7 @@ func init() {
 			name:   config.FormatFlag,
 			short:  "f",
 			value:  "",
-			usage:  "Output format. [env-var|aws-credentials]",
+			usage:  "Output format. [env-var|aws-credentials|credentials-provider]",
 			envVar: config.FormatEnvVar,
 		},
 		{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,8 @@ const (
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"
+	// CredentialProviderFormat format const
+	CredentialProviderFormat = "credential-provider"
 	// EnvVarFormat format const
 	EnvVarFormat = "env-var"
 

--- a/internal/output/credential_provider.go
+++ b/internal/output/credential_provider.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/okta/okta-aws-cli/internal/aws"
+	"github.com/okta/okta-aws-cli/internal/config"
+	"github.com/pkg/errors"
+)
+
+// CredentialProvider defines how to output AWS credentials in the
+// format used by the AWS credentials provider feature.
+type CredentialProvider struct {
+	Version         uint   `json:"Version"`
+	AccessKeyID     string `json:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	SessionToken    string `json:"SessionToken"`
+	Expiration      string `json:"Expiration"`
+}
+
+// NewCredentialProvider Creates a new
+func NewCredentialProvider(expiry string) *CredentialProvider {
+	return &CredentialProvider{
+		Version:    1,
+		Expiration: expiry,
+	}
+}
+
+// Output Satisfies the Outputter interface and outputs credential
+// provider JSON to STDOUT.
+func (e *CredentialProvider) Output(c *config.Config, ac *aws.Credential) error {
+	e.AccessKeyID = ac.AccessKeyID
+	e.SecretAccessKey = ac.SecretAccessKey
+	e.SessionToken = ac.SessionToken
+	serialized, err := json.Marshal(e)
+	if err != nil {
+		return errors.Wrap(err, "could not serialize credential provider")
+	}
+	_, err = fmt.Print(string(serialized))
+	return err
+}

--- a/internal/output/credential_provider.go
+++ b/internal/output/credential_provider.go
@@ -35,7 +35,7 @@ type CredentialProvider struct {
 	Expiration      string `json:"Expiration"`
 }
 
-// NewCredentialProvider Creates a new
+// NewCredentialProvider creates a new JSON-serializable credential provider.
 func NewCredentialProvider(expiry string) *CredentialProvider {
 	return &CredentialProvider{
 		Version:    1,

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -325,14 +325,22 @@ func (s *SessionToken) renderCredential(ac *oaws.Credential) error {
 	var o output.Outputter
 	switch s.config.Format() {
 	case config.AWSCredentialsFormat:
-		expiry := time.Now().Add(time.Duration(s.config.AWSSessionDuration()) * time.Second).Format(time.RFC3339)
-		o = output.NewAWSCredentialsFile(s.config.LegacyAWSVariables(), s.config.ExpiryAWSVariables(), expiry)
+		o = output.NewAWSCredentialsFile(s.config.LegacyAWSVariables(), s.config.ExpiryAWSVariables(), s.credentialExpiration())
+	case config.CredentialProviderFormat:
+		o = output.NewCredentialProvider(s.credentialExpiration())
+		fmt.Fprintf(os.Stderr, "\n")
 	default:
 		o = output.NewEnvVar(s.config.LegacyAWSVariables())
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 
 	return o.Output(s.config, ac)
+}
+
+// credentialExpiration is the RFC 3339 compliant timestamp which
+// indicates when the credentials expire.
+func (s *SessionToken) credentialExpiration() string {
+	return time.Now().Add(time.Duration(s.config.AWSSessionDuration()) * time.Second).Format(time.RFC3339)
 }
 
 // fetchAWSCredentialWithSAMLRole Get AWS Credentials with an STS Assume Role With SAML AWS


### PR DESCRIPTION
Credential provider support is needed so that we can just set a credential provider in the local AWS config file, and then we don't have to run a separate command before practically every AWS CLI command or app using an AWS SDK. `okta-aws-cli` will be run automatically as part of the credential provider chain.

[AWS docs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html)

See README changes (new section) for how this works in practice.

_Note to self: do not delete branch, will be used to upstream changes._