### PR TITLE
chore: update to v1.2.2 (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Setup Go Tools
         run: make tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
         with:
-          go-version: 1.19
+          go-version: 1.21
       -
         name: Import GPG key
         id: import_gpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.2 (August 30, 2023)
+
+* Ensure evaluation of CLI flag for profile is in the same order as the other flags [#124](https://github.com/okta/okta-aws-cli/pull/124)
+* Retry cached access token if it isn't expired by but receives API error [#127](https://github.com/okta/okta-aws-cli/pull/127)
+
 ## 1.2.1 (August 15, 2023)
 
 * Friendly IdP and Role labels don't also print out ARN value (less text clutter in the UI)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// Version app version
-	Version = "1.2.1"
+	Version = "1.2.2"
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"


### PR DESCRIPTION
* If the cached token is not expired, but somehow became invalid go through the device auth loop again.

Closes #118

* Preparing 1.2.2 release

* bump go version in GH actions

---------